### PR TITLE
DB-60: Fix: delete _id field

### DIFF
--- a/models.go
+++ b/models.go
@@ -564,7 +564,6 @@ type IPAddress struct {
 	NetMask string `json:"netmask"`
 }
 type CPE struct {
-	ID          UUID         `json:"id" bson:"_id"`
 	Name        string       `json:"name"`
 	Connected   bool         `json:"connected"`
 	Description string       `json:"description"`


### PR DESCRIPTION
Fix: delete _id field from CPE struct 